### PR TITLE
Upgrade with all FP2004 features and binary classification functionality

### DIFF
--- a/example_boston.py
+++ b/example_boston.py
@@ -12,21 +12,14 @@ X = boston_data.drop("medv", axis=1)
 features = X.columns
 X = X.as_matrix()
 
-typ='classifier'
-use_mt_feats=True
+typ='classifier' #regressor or classifier
 
-if use_mt_feats:
-    incr_feats=[6,9]
-    decr_feats=[1,8,12,13]
-else:
-    incr_feats=None
-    decr_feats=None
         
 if typ=='regressor':
 
     rf = RuleFit(tree_size=4,sample_fract='default',max_rules=2000,
              memory_par=0.01,
-             tree_generator=None,n_feats=X.shape[1],incr_feats=incr_feats,decr_feats=decr_feats,
+             tree_generator=None,n_feats=X.shape[1],
             rfmode='regress',lin_trim_quantile=0.025,
             lin_standardise=True, exp_rand_tree_size=True,random_state=1) 
     rf.fit(X, y, feature_names=features)
@@ -37,7 +30,7 @@ elif typ=='classifier':
     N=X.shape[0]
     rf = RuleFit(tree_size=4,sample_fract='default',max_rules=2000,
                  memory_par=0.01,
-                 tree_generator=None,n_feats=X.shape[1],incr_feats=incr_feats,decr_feats=decr_feats,
+                 tree_generator=None,n_feats=X.shape[1],
                 rfmode='classify',lin_trim_quantile=0.025,
                 lin_standardise=True, exp_rand_tree_size=True,random_state=1) 
     rf.fit(X, y_class, feature_names=features)

--- a/example_boston.py
+++ b/example_boston.py
@@ -12,17 +12,17 @@ X = boston_data.drop("medv", axis=1)
 features = X.columns
 X = X.as_matrix()
 
-typ='classifier' #regressor or classifier
+typ='regressor' #regressor or classifier
 
-        
 if typ=='regressor':
-
     rf = RuleFit(tree_size=4,sample_fract='default',max_rules=2000,
              memory_par=0.01,
              tree_generator=None,
             rfmode='regress',lin_trim_quantile=0.025,
             lin_standardise=True, exp_rand_tree_size=True,random_state=1) 
     rf.fit(X, y, feature_names=features)
+    y_pred=rf.predict(X)
+    insample_rmse=np.sqrt(np.sum((y_pred-y)**2)/len(y))
 elif typ=='classifier':
     y_class=y.copy()
     y_class[y_class<21]=-1
@@ -34,8 +34,8 @@ elif typ=='classifier':
                 rfmode='classify',lin_trim_quantile=0.025,
                 lin_standardise=True, exp_rand_tree_size=True,random_state=1) 
     rf.fit(X, y_class, feature_names=features)
-    
-y_pred=rf.predict(X)
+    y_pred=rf.predict(X)
+    insample_acc=len(y_pred==y_class)/len(y_class)
 rules = rf.get_rules()
 
 rules = rules[rules.coef != 0].sort_values(by="support")

--- a/example_boston.py
+++ b/example_boston.py
@@ -19,7 +19,7 @@ if typ=='regressor':
 
     rf = RuleFit(tree_size=4,sample_fract='default',max_rules=2000,
              memory_par=0.01,
-             tree_generator=None,n_feats=X.shape[1],
+             tree_generator=None,
             rfmode='regress',lin_trim_quantile=0.025,
             lin_standardise=True, exp_rand_tree_size=True,random_state=1) 
     rf.fit(X, y, feature_names=features)
@@ -30,12 +30,12 @@ elif typ=='classifier':
     N=X.shape[0]
     rf = RuleFit(tree_size=4,sample_fract='default',max_rules=2000,
                  memory_par=0.01,
-                 tree_generator=None,n_feats=X.shape[1],
+                 tree_generator=None,
                 rfmode='classify',lin_trim_quantile=0.025,
                 lin_standardise=True, exp_rand_tree_size=True,random_state=1) 
     rf.fit(X, y_class, feature_names=features)
     
-res1=rf.predict(X)
+y_pred=rf.predict(X)
 rules = rf.get_rules()
 
 rules = rules[rules.coef != 0].sort_values(by="support")

--- a/example_boston.py
+++ b/example_boston.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.ensemble import GradientBoostingRegressor,GradientBoostingClassifier
 from rulefit import RuleFit
 
 
@@ -12,11 +12,40 @@ X = boston_data.drop("medv", axis=1)
 features = X.columns
 X = X.as_matrix()
 
-gb = GradientBoostingRegressor(n_estimators=100, max_depth=3, learning_rate=0.01)
-rf = RuleFit(gb)
+typ='classifier'
+use_mt_feats=True
 
-rf.fit(X, y, feature_names=features)
+if use_mt_feats:
+    incr_feats=[6,9]
+    decr_feats=[1,8,12,13]
+else:
+    incr_feats=None
+    decr_feats=None
+        
+if typ=='regressor':
 
+    rf = RuleFit(tree_size=4,sample_fract='default',max_rules=2000,
+             memory_par=0.01,
+             tree_generator=None,n_feats=X.shape[1],incr_feats=incr_feats,decr_feats=decr_feats,
+            rfmode='regress',lin_trim_quantile=0.025,
+            lin_standardise=True, exp_rand_tree_size=True,random_state=1) 
+    rf.fit(X, y, feature_names=features)
+elif typ=='classifier':
+    y_class=y.copy()
+    y_class[y_class<21]=-1
+    y_class[y_class>=21]=+1
+    N=X.shape[0]
+    rf = RuleFit(tree_size=4,sample_fract='default',max_rules=2000,
+                 memory_par=0.01,
+                 tree_generator=None,n_feats=X.shape[1],incr_feats=incr_feats,decr_feats=decr_feats,
+                rfmode='classify',lin_trim_quantile=0.025,
+                lin_standardise=True, exp_rand_tree_size=True,random_state=1) 
+    rf.fit(X, y_class, feature_names=features)
+    
+res1=rf.predict(X)
 rules = rf.get_rules()
 
-rules = rules[rules.coef != 0].sort("support")
+rules = rules[rules.coef != 0].sort_values(by="support")
+num_rules_rule=len(rules[rules.type=='rule'])
+num_rules_linear=len(rules[rules.type=='linear'])
+

--- a/example_boston.py
+++ b/example_boston.py
@@ -12,7 +12,7 @@ X = boston_data.drop("medv", axis=1)
 features = X.columns
 X = X.as_matrix()
 
-typ='regressor' #regressor or classifier
+typ='classifier' #regressor or classifier
 
 if typ=='regressor':
     rf = RuleFit(tree_size=4,sample_fract='default',max_rules=2000,

--- a/rulefit/__init__.py
+++ b/rulefit/__init__.py
@@ -1,3 +1,3 @@
-from .rulefit import RuleCondition, Rule, RuleEnsemble, RuleFit
+from .rulefit import RuleCondition, Rule, RuleEnsemble, RuleFit, FriedScale
 
 __all__ = ["rulefit"]

--- a/rulefit/rulefit.py
+++ b/rulefit/rulefit.py
@@ -290,7 +290,27 @@ class RuleFit(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-        tree_generator: object GradientBoostingRegressor or GradientBoostingClassifier, optional (default=None)
+        tree_size:      Number of terminal nodes in generated trees. If exp_rand_tree_size=True, 
+                        this will be the mean number of terminal nodes.
+        sample_fract:   fraction of randomly chosen training observations used to produce each tree. 
+                        FP 2004 (Sec. 2)
+        max_rules:      approximate total number of rules generated for fitting. Note that actual
+                        number of rules will usually be lower than this due to duplicates.
+        memory_par:     scale multiplier (shrinkage factor) applied to each new tree when 
+                        sequentially induced. FP 2004 (Sec. 2)
+        rfmode:         'regress' for regression or 'classify' for binary classification.
+        lin_standardise: If True, the linear terms will be standardised as per Friedman Sec 3.2
+                        by multiplying the winsorised variable by 0.4/stdev.
+        lin_trim_quantile: If lin_standardise is True, this quantile will be used to trim linear 
+                        terms before standardisation.
+        exp_rand_tree_size: If True, each boosted tree will have a different maximum number of 
+                        terminal nodes based on an exponential distribution about tree_size. 
+                        (Friedman Sec 3.3)
+        model_type:     'r': rules only; 'l': linear terms only; 'rl': both rules and linear terms
+        random_state:   Integer to initialise random objects and provide repeatability.
+        tree_generator: Optional: this object will be used as provided to generate the rules. 
+                        This will override almost all the other properties above. 
+                        Must be GradientBoostingRegressor or GradientBoostingClassifier, optional (default=None)
 
     Attributes
     ----------
@@ -303,7 +323,7 @@ class RuleFit(BaseEstimator, TransformerMixin):
     """
     def __init__(self,tree_size=4,sample_fract='default',max_rules=2000,
                  memory_par=0.01,
-                 tree_generator=None,n_feats=None,
+                 tree_generator=None,
                 rfmode='regress',lin_trim_quantile=0.025,
                 lin_standardise=True, exp_rand_tree_size=True,
                 model_type='rl',random_state=None):

--- a/rulefit/rulefit.py
+++ b/rulefit/rulefit.py
@@ -168,11 +168,9 @@ def extract_rules_from_tree(tree, feature_names=None):
                                            support = tree.n_node_samples[node_id] / float(tree.n_node_samples[0]),
                                            feature_name=feature_name)
             new_conditions = conditions + [rule_condition]
-            #new_rule = Rule(new_conditions,tree.value[node_id][0][0])
-            #rules.update([new_rule])
         else:
             new_conditions = []
-                ## if not terminal node
+        ## if not terminal node
         if tree.children_left[node_id] != tree.children_right[node_id]: #not tree.feature[node_id] == -2:
             feature = tree.feature[node_id]
             threshold = tree.threshold[node_id]
@@ -187,7 +185,7 @@ def extract_rules_from_tree(tree, feature_names=None):
                 new_rule = Rule(new_conditions,tree.value[node_id][0][0])
                 rules.update([new_rule])
             else:
-                print('********** WHAT THE??? ****** ' + str(tree.node_count))
+                pass #tree only has a root node!
             return None
 
     traverse_nodes()
@@ -361,7 +359,6 @@ class RuleFit(BaseEstimator, TransformerMixin):
                     i=i+1
                 tree_sizes=tree_sizes[0:i]
                 self.tree_generator.set_params(warm_start=True) 
-    #            num_rules=0
                 for i_size in np.arange(len(tree_sizes)):
                     size=tree_sizes[i_size]
                     self.tree_generator.set_params(n_estimators=len(self.tree_generator.estimators_)+1)
@@ -369,13 +366,6 @@ class RuleFit(BaseEstimator, TransformerMixin):
                     self.tree_generator.set_params(random_state=i_size+self.random_state) # warm_state=True seems to reset random_state, such that the trees are highly correlated, unless we manually change the random_sate here.
                     self.tree_generator.get_params()['n_estimators']
                     self.tree_generator.fit(np.copy(X, order='C'), np.copy(y, order='C'))
-                    # count leaves (a check)
-    #                tree_=self.tree_generator.estimators_[j_][0].tree_
-    #                test_=tree_.children_left+ tree_.children_left
-    #                num_leaves=len(test_[test_==-2])
-    #                num_rules=num_rules+mean_leaves
-    #            print('num rules: ' + str(num_rules))
-    #                print('tree_size: ' + str(size) + ' mean actual number of leaf nodes: ' + str(mean_leaves) + ' for ' + str(cnt)+ ' trees')
                 self.tree_generator.set_params(warm_start=False) 
             tree_list = self.tree_generator.estimators_
             if isinstance(self.tree_generator, RandomForestRegressor) or isinstance(self.tree_generator, RandomForestClassifier):

--- a/rulefit/rulefit.py
+++ b/rulefit/rulefit.py
@@ -17,6 +17,37 @@ from sklearn.base import TransformerMixin
 from sklearn.ensemble import GradientBoostingRegressor, GradientBoostingClassifier, RandomForestRegressor, RandomForestClassifier
 from sklearn.linear_model import LassoCV
 from functools import reduce
+import  scipy 
+import cvglmnet
+import cvglmnetCoef
+import cvglmnetPlot
+import cvglmnetPredict
+
+class GLMCV():
+    def __init__(self,family='gaussian',incr_feats=None,decr_feats=None):
+        self.cvfit=None
+        self.family=family
+        self.incr_feats=np.asarray([]) if incr_feats is None else np.asarray(incr_feats)
+        self.decr_feats=np.asarray([]) if decr_feats is None else np.asarray(decr_feats)
+
+    def fit(self,x,y):        
+        cv_loss='class' if self.family=='binomial' else 'deviance'
+        coef_limits=scipy.array([[scipy.float64(-scipy.inf)], [scipy.float64(scipy.inf)]]) # default, no limits on coefs
+        # set up constraints
+        if  len( self.incr_feats)>0 or  len(self.decr_feats)>0 :
+            coef_limits=np.zeros([2,x.shape[1]])
+            for i_feat in np.arange(x.shape[1]):
+                coef_limits[0,i_feat]=-np.inf if i_feat not in self.incr_feats-1 else 0.
+                coef_limits[1,i_feat]=np.inf if i_feat not in self.decr_feats-1 else 0.
+            coef_limits=scipy.array(coef_limits)
+        self.cvfit = cvglmnet.cvglmnet(x = x.copy(), y = y.copy(), nfolds=5,family = self.family, ptype = cv_loss, nlambda = 20,intr=True,cl=coef_limits)
+        coef=cvglmnetCoef.cvglmnetCoef(self.cvfit, s = 'lambda_min')
+        self.coef_=coef[1:,0]
+        self.intercept_=coef[0,0]
+    def predict(self,x):
+        return cvglmnetPredict.cvglmnetPredict(self.cvfit, newx = x, s = 'lambda_min', ptype = 'class')
+        
+   
 
 class RuleCondition():
     """Class for binary rule condition
@@ -71,6 +102,39 @@ class RuleCondition():
         return hash((self.feature_index, self.threshold, self.operator, self.feature_name))
 
 
+class FriedScale():
+    """Performs scaling of linear variables according to Friedman et al. 2005 Sec 5
+
+    Each variable is firsst Winsorized l->l*, then standardised as 0.4 x l* / std(l*)
+    Warning: this class should not be used directly.
+    """    
+    def __init__(self,trim_quantile=0.0):
+        self.trim_quantile=trim_quantile
+        self.scale_multipliers=None
+        self.winsor_lims=None
+        
+    def train(self,X):
+        # get winsor limits
+        self.winsor_lims=np.ones([2,X.shape[1]])*np.inf
+        self.winsor_lims[0,:]=-np.inf
+        if self.trim_quantile>0:
+            for i_col in np.arange(X.shape[1]):
+                lower=np.percentile(X[:,i_col],self.trim_quantile*100)
+                upper=np.percentile(X[:,i_col],100-self.trim_quantile*100)
+                self.winsor_lims[:,i_col]=[lower,upper]
+        # get multipliers
+        scale_multipliers=np.ones(X.shape[1])
+        for i_col in np.arange(X.shape[1]):
+            num_uniq_vals=len(np.unique(X[:,i_col]))
+            if num_uniq_vals>2: # don't scale binary variables which are effectively already rules
+                X_col_winsorised=X[:,i_col].copy()
+                X_col_winsorised[X_col_winsorised<self.winsor_lims[0,i_col]]=self.winsor_lims[0,i_col]
+                X_col_winsorised[X_col_winsorised>self.winsor_lims[1,i_col]]=self.winsor_lims[1,i_col]
+                scale_multipliers[i_col]=0.4/np.std(X_col_winsorised)
+        self.scale_multipliers=scale_multipliers
+        
+    def scale(self,X):
+        return X*self.scale_multipliers
 
 class Rule():
     """Class for binary Rules from list of conditions
@@ -78,10 +142,11 @@ class Rule():
     Warning: this class should not be used directly.
     """
     def __init__(self,
-                 rule_conditions):
+                 rule_conditions,value):
         self.conditions = set(rule_conditions)
         self.support = min([x.support for x in rule_conditions])
-
+        self.value=value
+        self.rule_direction=None
     def transform(self, X):
         """Transform dataset.
 
@@ -130,25 +195,30 @@ def extract_rules_from_tree(tree, feature_names=None):
                                            support = tree.n_node_samples[node_id] / float(tree.n_node_samples[0]),
                                            feature_name=feature_name)
             new_conditions = conditions + [rule_condition]
-            new_rule = Rule(new_conditions)
-            rules.update([new_rule])
+            #new_rule = Rule(new_conditions,tree.value[node_id][0][0])
+            #rules.update([new_rule])
         else:
             new_conditions = []
                 ## if not terminal node
-        if not tree.feature[node_id] == -2:
+        if tree.children_left[node_id] != tree.children_right[node_id]: #not tree.feature[node_id] == -2:
             feature = tree.feature[node_id]
             threshold = tree.threshold[node_id]
-
+            
             left_node_id = tree.children_left[node_id]
             traverse_nodes(left_node_id, "<=", threshold, feature, new_conditions)
-
+            
             right_node_id = tree.children_right[node_id]
             traverse_nodes(right_node_id, ">", threshold, feature, new_conditions)
-        else:
+        else: # a leaf node
+            if len(new_conditions)>0:
+                new_rule = Rule(new_conditions,tree.value[node_id][0][0])
+                rules.update([new_rule])
+            else:
+                print('********** WHAT THE??? ****** ' + str(tree.node_count))
             return None
 
     traverse_nodes()
-
+    
     return rules
 
 
@@ -180,6 +250,7 @@ class RuleEnsemble():
         self.rules = set()
         ## TODO: Move this out of __init__
         self._extract_rules()
+        self.rules=list(self.rules)
 
     def _extract_rules(self):
         """Recursively extract rules from each tree in the ensemble
@@ -195,7 +266,7 @@ class RuleEnsemble():
     def filter_short_rules(self, k):
         self.filter_rules(lambda x: len(x.conditions) > k)
 
-    def transform(self, X):
+    def transform(self, X,coefs=None):
         """Transform dataset.
 
         Parameters
@@ -207,8 +278,14 @@ class RuleEnsemble():
         X_transformed: array-like matrix, shape=(n_samples, n_out)
             Transformed dataset. Each column represents one rule.
         """
-        return np.array([rule.transform(X) for rule in self.rules]).T
-
+        rule_list=list(self.rules) 
+        if   coefs is None:
+            return np.array([rule.transform(X) for rule in rule_list]).T
+        else: # else use the coefs to filter the rules we bother to interpret
+            res= np.array([rule_list[i_rule].transform(X) for i_rule in np.arange(len(rule_list)) if coefs[i_rule]!=0]).T
+            res_=np.zeros([X.shape[0],len(rule_list)])
+            res_[:,coefs!=0]=res
+            return res_
     def __str__(self):
         return (map(lambda x: x.__str__(), self.rules)).__str__()
 
@@ -232,65 +309,160 @@ class RuleFit(BaseEstimator, TransformerMixin):
         The names of the features (columns)
 
     """
-    def __init__(self,
-                 tree_generator=None):
+    def __init__(self,tree_size=4,sample_fract='default',max_rules=2000,
+                 memory_par=0.01,
+                 tree_generator=None,n_feats=None,incr_feats=[],decr_feats=[],
+                rfmode='regress',lin_trim_quantile=0.025,
+                lin_standardise=True, exp_rand_tree_size=True,
+                model_type='rl',random_state=None):
         self.tree_generator = tree_generator
-
-
+        self.n_feats=n_feats
+        self.incr_feats=np.asarray([] if incr_feats is None else incr_feats)
+        self.decr_feats=np.asarray([] if decr_feats is None else decr_feats)
+        self.mt_feats=np.asarray(list(self.incr_feats)+list(self.decr_feats))
+        self.nmt_feats=np.asarray([j for j in np.arange(n_feats)+1 if j not in self.mt_feats])
+        self.rfmode=rfmode
+        self.lin_trim_quantile=lin_trim_quantile
+        self.lin_standardise=lin_standardise
+        self.friedscale=FriedScale(trim_quantile=lin_trim_quantile)
+        self.exp_rand_tree_size=exp_rand_tree_size
+        self.max_rules=max_rules
+        self.sample_fract=sample_fract 
+        self.max_rules=max_rules
+        self.memory_par=memory_par
+        self.tree_size=tree_size
+        self.random_state=random_state
+        self.model_type=model_type
+        
     def fit(self, X, y=None, feature_names=None):
         """Fit and estimate linear combination of rule ensemble
 
         """
         ## Enumerate features if feature names not provided
+        N=X.shape[0]
         if feature_names is None:
             self.feature_names = ['feature_' + str(x) for x in range(0, X.shape[1])]
         else:
             self.feature_names=feature_names
-
-        ## initialise tree generator
-        if self.tree_generator is None:
-            self.tree_generator = GradientBoostingRegressor()
-
-        if type(self.tree_generator) not in [GradientBoostingRegressor,
-                                             GradientBoostingClassifier,
-                                             RandomForestRegressor,
-                                             RandomForestClassifier]:
-            raise ValueError("RuleFit only works with RandomForest and BoostingRegressor")
-        ## TODO: Error if tree generator not GB nor RF
-
-        ## fit tree generator
-        self.tree_generator.fit(X, y)
-
-        tree_list = self.tree_generator.estimators_
-        if isinstance(self.tree_generator, RandomForestRegressor) or isinstance(self.tree_generator, RandomForestClassifier):
-             tree_list = [[x] for x in self.tree_generator.estimators_]
-        ## extract rules
-        self.rule_ensemble = RuleEnsemble(tree_list = tree_list,
-                                          feature_names=self.feature_names)
-
-        ## concatenate original features and rules
-        X_rules = self.rule_ensemble.transform(X)
-        ## No rules found
-        if X_rules.shape[0] == 0:
-            X_concat = X
-        else:
-            X_concat = np.concatenate((X, X_rules), axis=1)
+        if 'r' in self.model_type:
+            ## initialise tree generator
+            if self.tree_generator is None:
+                n_estimators_default=int(np.ceil(self.max_rules/self.tree_size))
+                self.sample_fract_=min(0.5,(100+6*np.sqrt(N))/N)
+                if   self.rfmode=='regress':
+                    self.tree_generator = GradientBoostingRegressor(n_estimators=n_estimators_default, max_leaf_nodes=self.tree_size, learning_rate=self.memory_par,subsample=self.sample_fract_,random_state=self.random_state,max_depth=100)
+                else:
+                    self.tree_generator =GradientBoostingClassifier(n_estimators=n_estimators_default, max_leaf_nodes=self.tree_size, learning_rate=self.memory_par,subsample=self.sample_fract_,random_state=self.random_state,max_depth=100)
+    
+            if   self.rfmode=='regress':
+                if type(self.tree_generator) not in [GradientBoostingRegressor,RandomForestRegressor]:
+                    raise ValueError("RuleFit only works with RandomForest and BoostingRegressor")
+            else:
+                if type(self.tree_generator) not in [GradientBoostingClassifier,RandomForestClassifier]:
+                    raise ValueError("RuleFit only works with RandomForest and BoostingClassifier")
+    
+            ## fit tree generator
+            if not self.exp_rand_tree_size: # simply fit with constant tree size
+                self.tree_generator.fit(X, y)
+            else: # randomise tree size as per Friedman 2005 Sec 3.3
+                np.random.seed(self.random_state)
+                tree_sizes=np.random.exponential(scale=self.tree_size-2,size=int(np.ceil(self.max_rules*2/self.tree_size)))
+                tree_sizes=np.asarray([2+np.floor(tree_sizes[i_]) for i_ in np.arange(len(tree_sizes))],dtype=int)
+                i=int(len(tree_sizes)/4)
+                while np.sum(tree_sizes[0:i])<self.max_rules:
+                    i=i+1
+                tree_sizes=tree_sizes[0:i]
+                self.tree_generator.set_params(warm_start=True) 
+    #            num_rules=0
+                for i_size in np.arange(len(tree_sizes)):
+                    size=tree_sizes[i_size]
+                    self.tree_generator.set_params(n_estimators=len(self.tree_generator.estimators_)+1)
+                    self.tree_generator.set_params(max_leaf_nodes=size)
+                    self.tree_generator.set_params(random_state=i_size+self.random_state) # warm_state=True seems to reset random_state, such that the trees are highly correlated, unless we manually change the random_sate here.
+                    self.tree_generator.get_params()['n_estimators']
+                    self.tree_generator.fit(np.copy(X, order='C'), np.copy(y, order='C'))
+                    # count leaves (a check)
+    #                tree_=self.tree_generator.estimators_[j_][0].tree_
+    #                test_=tree_.children_left+ tree_.children_left
+    #                num_leaves=len(test_[test_==-2])
+    #                num_rules=num_rules+mean_leaves
+    #            print('num rules: ' + str(num_rules))
+    #                print('tree_size: ' + str(size) + ' mean actual number of leaf nodes: ' + str(mean_leaves) + ' for ' + str(cnt)+ ' trees')
+                self.tree_generator.set_params(warm_start=False) 
+            tree_list = self.tree_generator.estimators_
+            if isinstance(self.tree_generator, RandomForestRegressor) or isinstance(self.tree_generator, RandomForestClassifier):
+                 tree_list = [[x] for x in self.tree_generator.estimators_]
+                 
+            ## extract rules
+            self.rule_ensemble = RuleEnsemble(tree_list = tree_list,
+                                              feature_names=self.feature_names)
+            ## filter for upper and lower rules only (if needed)
+            self.num_rules_peak_=len(self.rule_ensemble.rules)
+            if len(self.mt_feats)>0: 
+                filtered_rules=set()
+                for rule in self.rule_ensemble.rules:
+                    conditions=list(rule.conditions)
+                    all_incr=np.all([conditions[c].operator[0]==('>' if conditions[c].feature_index in self.incr_feats-1 else '<') for c in [cc for cc in np.arange(len(conditions)) if conditions[cc].feature_index in self.mt_feats-1]])
+                    all_decr=np.all([conditions[c].operator[0]==('<' if conditions[c].feature_index in self.incr_feats-1 else '>') for c in [cc for cc in np.arange(len(conditions)) if conditions[cc].feature_index in self.mt_feats-1]])
+                    if (all_incr and rule.value>0) or (all_decr and rule.value<0):
+                        rule.rule_direction=+1 if all_incr else -1
+                        filtered_rules.add(rule)
+                #print('started with ' + str(len(self.rule_ensemble.rules)) + ' rules, now have ' + str(len(filtered_rules)))
+                self.rule_ensemble.rules=list(filtered_rules)
+            ## concatenate original features and rules
+            X_rules = self.rule_ensemble.transform(X)
+        
+        ## standardise linear variables if requested (for regression model only)
+        if 'l' in self.model_type: 
+            if self.lin_standardise:
+                self.friedscale.train(X)
+                X_regn=self.friedscale.scale(X)
+            else:
+                X_regn=X.copy()            
+        
+        ## Compile Training data
+        X_concat=np.zeros([X.shape[0],0])
+        if 'l' in self.model_type:
+            X_concat = np.concatenate((X_concat,X_regn), axis=1)
+        if 'r' in self.model_type:
+            if X_rules.shape[0] >0:
+                X_concat = np.concatenate((X_concat, X_rules), axis=1)
 
         ## initialise Lasso
-        self.lscv = LassoCV()
+        if len(self.mt_feats)==0:
+            if self.rfmode=='regress':
+                self.lscv = LassoCV()
+            else:
+                self.lscv=GLMCV(family='binomial')
+        else:
+            rule_dirns=np.asarray([r.rule_direction for r in self.rule_ensemble.rules])
+            incr_feats_with_rules=np.asarray(np.hstack([self.incr_feats,self.n_feats+np.asarray([i_rule+1 for i_rule in np.arange(len(rule_dirns)) if rule_dirns[i_rule]>0])]))
+            decr_feats_with_rules=np.asarray(np.hstack([self.decr_feats,self.n_feats+np.asarray([i_rule+1 for i_rule in np.arange(len(rule_dirns)) if rule_dirns[i_rule]<0])]))
+            if self.rfmode=='regress':
+                self.lscv=GLMCV(family='gaussian',incr_feats=incr_feats_with_rules,decr_feats=decr_feats_with_rules)
+            else:
+                self.lscv=GLMCV(family='binomial',incr_feats=incr_feats_with_rules,decr_feats=decr_feats_with_rules)
 
         ## fit Lasso
         self.lscv.fit(X_concat, y)
+        
         return self
 
     def predict(self, X):
         """Predict outcome for X
 
         """
-
-        X_rules = self.rule_ensemble.transform(X)
-        X_concat = np.concatenate((X, X_rules), axis=1)
-
+        X_concat=np.zeros([X.shape[0],0])
+        if 'l' in self.model_type:
+            if self.lin_standardise:
+                X_concat = np.concatenate((X_concat,self.friedscale.scale(X)), axis=1)
+            else:
+                X_concat = np.concatenate((X_concat,X), axis=1)
+        if 'r' in self.model_type:
+            rule_coefs=self.lscv.coef_[self.n_feats:]
+            X_rules = self.rule_ensemble.transform(X,coefs=rule_coefs)
+            if X_rules.shape[0] >0:
+                X_concat = np.concatenate((X_concat, X_rules), axis=1)
         return self.lscv.predict(X_concat)
 
     def transform(self, X=None, y=None):
@@ -329,12 +501,17 @@ class RuleFit(BaseEstimator, TransformerMixin):
         output_rules = []
         ## Add coefficients for linear effects
         for i in range(0, n_features):
-            output_rules += [(self.feature_names[i], 'linear', self.lscv.coef_[i], 1)]
+            if self.lin_standardise:
+                coef=self.lscv.coef_[i ]*self.friedscale.scale_multipliers[i]
+            else:
+                coef=self.lscv.coef_[i ]
+            output_rules += [(self.feature_names[i], 'linear',coef, 1)]
         ## Add rules
         for i in range(0, len(self.rule_ensemble.rules)):
             rule = rule_ensemble[i]
-            output_rules += [(rule.__str__(), 'rule', self.lscv.coef_[i + n_features],  rule.support)]
-        rules = pd.DataFrame(output_rules, columns=["rule", "type","coef", "support"])
+            coef=self.lscv.coef_[i + n_features]
+            output_rules += [(rule.__str__(), 'rule', coef,  rule.support,rule.rule_direction)]
+        rules = pd.DataFrame(output_rules, columns=["rule", "type","coef", "support","dirn"])
         if exclude_zero_coef:
             rules = rules.ix[rules.coef != 0]
         return rules

--- a/test_rulefit.py
+++ b/test_rulefit.py
@@ -1,4 +1,4 @@
-from rulefit import RuleCondition, Rule, RuleEnsemble, RuleFit
+from rulefit import FriedScale, RuleCondition, Rule, RuleEnsemble, RuleFit
 import numpy as np
 
 
@@ -21,7 +21,7 @@ def test_rule_condition_hashing_different1():
 def test_rule_condition_hashing_different2():
     assert (RuleCondition(1, 5, ">", 0.4) != RuleCondition(1, 5, "<=", 0.4))
 
-def test_rule_condition_hashing_different2():
+def test_rule_condition_hashing_different3():
     assert (RuleCondition(2, 5, ">", 0.4) != RuleCondition(1, 5, ">", 0.4))
 
 def test_rule_condition_smaller():
@@ -34,17 +34,42 @@ def test_rule_condition_greater():
 
 
 ## Testing rule
-rule = Rule([rule_condition_smaller, rule_condition_greater])
+rule = Rule([rule_condition_smaller, rule_condition_greater],0)
 
 def test_rule_transform():
     np.testing.assert_array_equal(rule.transform(X),
                                   np.array([0,1,0]))
 
 def test_rule_equality():
-    rule2 = Rule([rule_condition_greater, rule_condition_smaller])
+    rule2 = Rule([rule_condition_greater, rule_condition_smaller],0)
     assert rule == rule2
 
 
+## Testing FriedScale():
+def test_fried_scale():
+    x_scale_test=np.zeros([100,2])
+    x_scale_test[0:5,0]=-100
+    x_scale_test[5:10,0]=100
+    x_scale_test[10:55,0]=1
+    x_scale_test[5:55,1]=1 # winsorised version of first column at trim=0.1: note, will not be scaled because it is already an indicator function, as per FP004
+    fs=FriedScale(trim_quantile=0.1)
+    fs.train(x_scale_test)
+    np.testing.assert_array_equal(fs.scale(x_scale_test),
+                                  np.hstack([x_scale_test[:,1].reshape([-1,1])*0.4/np.std(x_scale_test[:,1]),x_scale_test[:,1].reshape([-1,1])]))
+
+def run_all_tests():
+    test_rule_condition_hashing_equal1()
+    test_rule_condition_hashing_equal2()
+    test_rule_condition_hashing_different1()
+    test_rule_condition_hashing_different2()
+    test_rule_condition_hashing_different3()
+    test_rule_condition_smaller()
+    test_rule_condition_greater()
+    test_rule_transform()
+    test_rule_equality()
+    test_fried_scale()
+    
+run_all_tests()
 ## Test rule extractions function
 ## TODO
 


### PR DESCRIPTION
Christoph, 

This has quite a lot of changes and additional features to make it more like the original paper, and the
interface more like Friedman's R implementation (http://statweb.stanford.edu/~jhf/r-rulefit/RuleFit_help.html). I don't mind if you don't want to accept this pull request as this branch serves my purposes, I won't be offended :) Thanks again for the great code it really sped up my development.

Changes:
- Added: use of Friedman standardisation on linear variables (Winsorised
and scaled by 0.4/stdev)
- Added: use of Friedman randomisation of number of terminal nodes using
exponential distribution
- Fixed: use of a set (i.e. unordered) for rules sometimes caused wrong
coefficients to be associiated with the wrong rules! Rules are now stored as a list (ie
ordered)
- Improved: sped up prediction by not evaluating rules with zero
coefficients
- Added: Max rules parameter like Friedman
- Added: Invisible use of BoostingRegressor/Classifier (created
according to constructor parameters, like Friedman's R implementation)
- Fixed: now only creates rules at terminal (leaf nodes) not branch nodes.
- Added: Now has 'regress' and 'classify' modes.
- Added: 'Classify' mode uses LogisticRegressionCV with L1 regularisation penalty
- Added: Added model_type parameter to allow rules/linear terms or both like R version.

Issues:
 - Classification is only checked for binary (two class) at the moment.
 - LogisticRegressionCV is not generating very sparse rulesets even though I've specified L1 penalty... not sure why. Possibly hyperparameters and CV parameters need some tuning.

Cheers, 

Chris