### PR TITLE
Bugfixes and change to default behavior of get_rules

### DIFF
--- a/rulefit/rulefit.py
+++ b/rulefit/rulefit.py
@@ -101,7 +101,7 @@ class FriedScale():
         for i_col in np.arange(X.shape[1]):
             num_uniq_vals=len(np.unique(X[:,i_col]))
             if num_uniq_vals>2: # don't scale binary variables which are effectively already rules
-                scale_multipliers[i_col]=0.4/(1.0e-12 + np.std(X_trimmed[:,i_col])) 
+                scale_multipliers[i_col]=0.4/(1.0e-12 + np.std(X_trimmed[:,i_col])
         self.scale_multipliers=scale_multipliers
         
     def scale(self,X,winsorize=True):
@@ -426,7 +426,7 @@ class RuleFit(BaseEstimator, TransformerMixin):
         else:
             if self.Cs is None:
                 Cs=10
-            self.lscv=LogisticRegressionCV(Cs=Cs,cv=self.cv,penalty='l1',random_state=self.random_state,solver='liblinear')
+            self.lscv=LogisticRegressionCV(Cs=self.Cs,cv=self.cv,penalty='l1',random_state=self.random_state,solver='liblinear')
             self.lscv.fit(X_concat, y)
             self.coef_=self.lscv.coef_[0]
             self.intercept_=self.lscv.intercept_[0]

--- a/rulefit/rulefit.py
+++ b/rulefit/rulefit.py
@@ -101,7 +101,7 @@ class FriedScale():
         for i_col in np.arange(X.shape[1]):
             num_uniq_vals=len(np.unique(X[:,i_col]))
             if num_uniq_vals>2: # don't scale binary variables which are effectively already rules
-                scale_multipliers[i_col]=0.4/np.std(X_trimmed[:,i_col])
+                scale_multipliers[i_col]=0.4/(1.0e-12 + np.std(X_trimmed[:,i_col])) 
         self.scale_multipliers=scale_multipliers
         
     def scale(self,X,winsorize=True):

--- a/rulefit/rulefit.py
+++ b/rulefit/rulefit.py
@@ -490,9 +490,9 @@ class RuleFit(BaseEstimator, TransformerMixin):
         ## Add coefficients for linear effects
         for i in range(0, n_features):
             if self.lin_standardise:
-                coef=self.coef_[i ]*self.friedscale.scale_multipliers[i]
+                coef=self.coef_[i]*self.friedscale.scale_multipliers[i]
             else:
-                coef=self.coef_[i ]
+                coef=self.coef_[i]
             output_rules += [(self.feature_names[i], 'linear',coef, 1)]
         ## Add rules
         for i in range(0, len(self.rule_ensemble.rules)):

--- a/rulefit/rulefit.py
+++ b/rulefit/rulefit.py
@@ -469,7 +469,7 @@ class RuleFit(BaseEstimator, TransformerMixin):
         """
         return self.rule_ensemble.transform(X)
 
-    def get_rules(self, exclude_zero_coef=True):
+    def get_rules(self, exclude_zero_coef=False):
         """Return the estimated rules
 
         Parameters


### PR DESCRIPTION
I fixed two bugs I ran into:

1) If one of the feature columns has a constant feature, then its standard deviation will be zero, and the friedman scaling done will have a divide by 0 error. I added a small constant to prevent this division by zero.

2) If Cs is passed to RuleFit when instantiating the object, it won't be passed properly to the LogisticRegression subroutine -- it should be self.Cs, instead of Cs.

I also ran into quirky behavior with get_rules versus transform. When transforming, I would get out a matrix with 116 columns, corresponding to 116 transformed features. When inspecting the rules with the output of get_rules, the total number of rules would only be 115. This was pretty frustrating, but I tracked down the source of the issue to be that when exclude_zero_coef was set to True, one of the rules was being eliminated. I think that the behavior between get_rules and transform should be identical -- either the variables with zero coefficient are eliminated from both, or neither. So this change at least makes the two consistent.