### PR TITLE
Add Probability Prediction Method

### DIFF
--- a/example_boston.py
+++ b/example_boston.py
@@ -35,10 +35,10 @@ elif typ=='classifier':
                 lin_standardise=True, exp_rand_tree_size=True,random_state=1) 
     rf.fit(X, y_class, feature_names=features)
     y_pred=rf.predict(X)
+    y_proba = rf.predict_proba(X)
     insample_acc=len(y_pred==y_class)/len(y_class)
 rules = rf.get_rules()
 
 rules = rules[rules.coef != 0].sort_values(by="support")
 num_rules_rule=len(rules[rules.type=='rule'])
 num_rules_linear=len(rules[rules.type=='linear'])
-

--- a/rulefit/rulefit.py
+++ b/rulefit/rulefit.py
@@ -476,6 +476,33 @@ class RuleFit(BaseEstimator, TransformerMixin):
                     X_concat = np.concatenate((X_concat, X_rules), axis=1)
         return self.lscv.predict(X_concat)
 
+    def predict_proba(self, X):
+        """Predict outcome probability for X, if model type supports probability prediction method
+
+        """
+
+        if 'predict_proba' not in dir(self.lscv):
+
+            error_message = '''
+            Probability prediction using predict_proba not available for
+            model type {lscv}
+            '''.format(lscv=self.lscv)
+            raise ValueError(error_message)
+
+        X_concat=np.zeros([X.shape[0],0])
+        if 'l' in self.model_type:
+            if self.lin_standardise:
+                X_concat = np.concatenate((X_concat,self.friedscale.scale(X)), axis=1)
+            else:
+                X_concat = np.concatenate((X_concat,X), axis=1)
+        if 'r' in self.model_type:
+            rule_coefs=self.coef_[-len(self.rule_ensemble.rules):]
+            if len(rule_coefs)>0:
+                X_rules = self.rule_ensemble.transform(X,coefs=rule_coefs)
+                if X_rules.shape[0] >0:
+                    X_concat = np.concatenate((X_concat, X_rules), axis=1)
+        return self.lscv.predict_proba(X_concat)
+
     def transform(self, X=None, y=None):
         """Transform dataset.
 

--- a/test_predict.py
+++ b/test_predict.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import numpy as np
+
+from rulefit import RuleFit
+
+#load data
+boston_data = pd.read_csv("boston.csv", index_col=0)
+
+y = boston_data.medv.values
+X = boston_data.drop("medv", axis=1)
+features = X.columns
+X = X.as_matrix()
+
+y_class = y.copy()
+y_class[y_class < 21] = 0
+y_class[y_class >= 21] = +1
+N = X.shape[0]
+
+#fit
+rf = RuleFit(tree_size=4, sample_fract='default', max_rules=2000,
+             memory_par=0.01,
+             tree_generator=None,
+             rfmode='classify', lin_trim_quantile=0.025,
+             lin_standardise=True, exp_rand_tree_size=True, random_state=1)
+rf.fit(X, y_class, feature_names=features)
+
+#predict
+y_pred = rf.predict(X)
+y_proba = rf.predict_proba(X)
+
+#basic checks for probabilities
+assert np.min(y_proba) >= 0
+assert np.max(y_proba) <= 1
+
+#test that probabilities match actual predictions
+np.testing.assert_array_equal(np.rint(np.array(y_proba[:,1])), y_pred)
+


### PR DESCRIPTION
Add wrapper method to predict probabilities via `predict_proba`, if that method exists in the sklearn class lscv. 